### PR TITLE
Fix for special character formatting bug

### DIFF
--- a/src/helpers/format.js
+++ b/src/helpers/format.js
@@ -12,7 +12,7 @@ exports.formatRaw = (original) => {
     rawOriginal = rawOriginal.replace("</i>", "");
 
     // Punctuation
-    rawOriginal = rawOriginal.replace(/[.,/#!$%^&*;:"'{}=\-_`~()]/g, "");
+    rawOriginal = rawOriginal.replace(/[^a-zA-Z0-9]/g, "");
     rawOriginal = rawOriginal.replace(/\s{2,}/g, "");
     rawOriginal = rawOriginal.replace(String.fromCharCode(92), "");
 

--- a/test/test.js
+++ b/test/test.js
@@ -34,6 +34,14 @@ describe('checkAnswer', () => {
     });
 
     describe('special characters', () => {
+        it('should handle apostrophes', () => {
+            assert.strictEqual(checkAnswer('', '', `That '70s show`, `that 70's show`), true);
+            assert.strictEqual(checkAnswer('', '', `That '70s show`, `that 70s show`), true);
+        });
+        it('should handle dashes', () => {
+            assert.strictEqual(checkAnswer('', '', `tik-tok`, `tiktok`), true);
+            assert.strictEqual(checkAnswer('', '', `tik-tok`, `tik tok`), true);
+        });
         it('should handle all special characters', () => {
             assert.strictEqual(checkAnswer('', '', `tik-tok`, `tik *&/~-_+=|{}[]"'?/.>,<!@#$%^&*()tok`), true);
         });

--- a/test/test.js
+++ b/test/test.js
@@ -33,6 +33,12 @@ describe('checkAnswer', () => {
         });
     });
 
+    describe('special characters', () => {
+        it('should handle all special characters', () => {
+            assert.strictEqual(checkAnswer('', '', `tik-tok`, `tik *&/~-_+=|{}[]"'?/.>,<!@#$%^&*()tok`), true);
+        });
+    });
+
     describe('number component answers', () => {
         it('should return true when number answers are the same', () => {
             assert.strictEqual(checkAnswer('', '', '16 Candles', '16 Candles'), true);


### PR DESCRIPTION
While playing the game, I discovered that formatting for answers that include special characters was inconsistent and almost always had problems with hyphenated answers and apostrophes. 

I wrote a few tests that validated/replicated the bug I was seeing. I discovered that if all characters except for numbers and letters are replaced with an empty string, instead of listing the characters to be removed, the tests pass and the problem is resolved.